### PR TITLE
Возврат на win1251 (для Marketplace)

### DIFF
--- a/armax.umkaonline/lang/ru/install/index.php
+++ b/armax.umkaonline/lang/ru/install/index.php
@@ -1,6 +1,6 @@
 <?
-$MESS["armax.umkaonline_MODULE_NAME"] = "Umka365 ÐžÐ½Ð»Ð°Ð¹Ð½ ÐšÐ°ÑÑÐ°";
-$MESS["armax.umkaonline_MODULE_DESC"] = "Umka365 ÐžÐ½Ð»Ð°Ð¹Ð½ ÐšÐ°ÑÑÐ°";
+$MESS["armax.umkaonline_MODULE_NAME"] = "Umka365 Îíëàéí Êàññà";
+$MESS["armax.umkaonline_MODULE_DESC"] = "Umka365 Îíëàéí Êàññà";
 $MESS["armax.umkaonline_PARTNER_NAME"] = "ArMax";
 $MESS["armax.umkaonline_PARTNER_URI"] = "https://umka365.ru/";
 ?>

--- a/armax.umkaonline/lang/ru/lib/UmkaOnline.php
+++ b/armax.umkaonline/lang/ru/lib/UmkaOnline.php
@@ -1,5 +1,5 @@
 <?
-$MESS["SALE_UMKAONLINE_TITLE"] = "Ð£Ð¼ÐºÐ° ÐžÐ½Ð»Ð°Ð¹Ð½ Ð¤Ð¤Ð” 1.05";
-$MESS["SALE_CASHBOX_UMKAONLINE_SETTINGS_AUTH_LOGIN_LABEL"] = "Ð›Ð¾Ð³Ð¸Ð½ ÐºÐ°ÑÑÐ¸Ñ€Ð°";
-$MESS["SALE_CASHBOX_UMKAONLINE_SETTINGS_AUTH_PASS_LABEL"] = "ÐŸÐ°Ñ€Ð¾Ð»ÑŒ ÐºÐ°ÑÑÐ¸Ñ€Ð°";
-$MESS["SALE_CASHBOX_UMKAONLINE_CHECK_STATUS_WRONG_UUID"] = "ÐÐµ Ð±Ñ‹Ð» Ð¾Ð¿Ñ€ÐµÐ´ÐµÐ»ÐµÐ½ Ð¸Ð´ÐµÐ½Ñ‚Ð¸Ñ„Ð¸ÐºÐ°Ñ‚Ð¾Ñ€ Ñ‡ÐµÐºÐ°. Ð’ÐµÑ€Ð¾ÑÑ‚Ð½ÐµÐµ Ð²ÑÐµÐ³Ð¾, Ñ‡ÐµÐº Ð½Ðµ Ð±Ñ‹Ð» Ð½Ð°Ð¿ÐµÑ‡Ð°Ñ‚Ð°Ð½";
+$MESS["SALE_UMKAONLINE_TITLE"] = "Óìêà Îíëàéí ÔÔÄ 1.05";
+$MESS["SALE_CASHBOX_UMKAONLINE_SETTINGS_AUTH_LOGIN_LABEL"] = "Ëîãèí êàññèðà";
+$MESS["SALE_CASHBOX_UMKAONLINE_SETTINGS_AUTH_PASS_LABEL"] = "Ïàðîëü êàññèðà";
+$MESS["SALE_CASHBOX_UMKAONLINE_CHECK_STATUS_WRONG_UUID"] = "Íå áûë îïðåäåëåí èäåíòèôèêàòîð ÷åêà. Âåðîÿòíåå âñåãî, ÷åê íå áûë íàïå÷àòàí";


### PR DESCRIPTION
Модули для Bitrix Marketplace должны загружаться в кодировке Windows-1251. При установке на сайт пользователя, устанавливается версия соответствующая кодировке сайта (конвертируется автоматически).

https://dev.1c-bitrix.ru/learning/course/index.php?COURSE_ID=101&LESSON_ID=3221/#:~:text=%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%87%D0%B0%D0%BD%D0%B8%D0%B5:%20%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D0%B0%20%D0%BE%D0%B1%D0%BD%D0%BE%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B9%20%D0%B0%D0%B2%D1%82%D0%BE%D0%BC%D0%B0%D1%82%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B8%20%D0%BF%D0%B5%D1%80%D0%B5%D0%B2%D0%BE%D0%B4%D0%B8%D1%82%20%D1%8F%D0%B7%D1%8B%D0%BA%D0%BE%D0%B2%D1%8B%D0%B5%20%D1%84%D0%B0%D0%B9%D0%BB%D1%8B%20%D0%B8%D0%B7%20Win-1251